### PR TITLE
Fix wrong align of icons in Iconic Plugin

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -888,7 +888,7 @@ body.is-phone {
 
 .nav-files-container .tree-item-self .tree-item-icon {
     position: absolute;
-    right: 0;
+    /* right: 0; */
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Fix icon alignment in Iconic Plugin in files view by removing right-side positioning. Tested with Iconize plugin—no change to default icon placement.